### PR TITLE
Wiki links

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -42,7 +42,7 @@ $savant->addGlobal('frontend', $frontend);
 $savant->setClassToTemplateMapper(new \PEAR2Web\TemplateMapper());
 $savant->setTemplatePath(
     array(
-        __DIR__ . '/../vendor/www/pear2.php.net/PEAR2_SimpleChannelFrontend/templates/html/',
+        dirname(__DIR__) . '/vendor/www/pear2.php.net/PEAR2_SimpleChannelFrontend/templates/html/',
         __DIR__ . '/templates/pear2/html',
     )
 );
@@ -53,7 +53,7 @@ switch($frontend->options['format']) {
         break;
     case 'rss':
 	    $savant->addTemplatePath(
-	        __DIR__ . '/../vendor/www/pear2.php.net/PEAR2_SimpleChannelFrontend/templates/rss/'
+	        dirname(__DIR__) . '/vendor/www/pear2.php.net/PEAR2_SimpleChannelFrontend/templates/rss/'
 	    );
 	    break;
 }

--- a/www/templates/pear2/html/PackageBugs.tpl.php
+++ b/www/templates/pear2/html/PackageBugs.tpl.php
@@ -1,6 +1,6 @@
 <?php
 
-$openCount = $context->getGitHubOpenIssueCount();
+$openCount = $context->getGitHubIssueCount('open');
 
 if ($openCount == 0) {
     echo '<span>none open</span>';
@@ -8,7 +8,7 @@ if ($openCount == 0) {
     echo '<a href="' . $context->getGitHubOpenIssuesLink() . '" class="package-bugs-open">' . $openCount . ' open</a>';
 }
 
-$closedCount = $context->getGitHubClosedIssueCount();
+$closedCount = $context->getGitHubIssueCount('closed');
 
 if ($closedCount > 0) {
     echo ', <a href="' . $context->getGitHubClosedIssuesLink() . '" class="package-bugs-closed">' . $closedCount . ' closed</a>';

--- a/www/templates/pear2/html/PackageDetails.tpl.php
+++ b/www/templates/pear2/html/PackageDetails.tpl.php
@@ -51,12 +51,23 @@ if ($licenseURI) {
 ?>
             </td>
         </tr>
+<?php
+if ($context->hasGitHubWiki()) {
+?>        <tr>
+            <th>Documentation:</th>
+            <td><a href="<?php echo $context->getGitHubWikiLink() ?>">GitHub Wiki</a></td>
+        </tr>
+<?php
+}
+
+if ($context->hasGitHubIssues()) {
+?>
         <tr>
             <th>Issues:</th>
             <td><?php echo $savant->render($context, 'PackageBugs.tpl.php'); ?></td>
         </tr>
-
 <?php
+}
 if (   isset($parent->parent->context->options)
     && $parent->parent->context->options['view'] === 'package'
 ) {


### PR DESCRIPTION
OK, this time I've tested on a live copy, and can say with confidence that there are no error messages at any point.

In addition to fixing my silly mistake at #21, this patch adds a link to the GitHub wiki for projects that have it, and also makes issues appear only if projects use the GitHub issues.

This means that (finally), the links to Pyrus related packages won't be misleading... they'll be non-existent instead.

**NOTE:** Many repositories have the Wiki checked, but they don't have a single page in it, so a link is still displayed. Such repositories should have their wiki removed from the repository's admin settings.
