### PR TITLE
Compatibility with PHP 5.3.2+.

### DIFF
--- a/src/PEAR2Web/Models/Package.php
+++ b/src/PEAR2Web/Models/Package.php
@@ -16,7 +16,7 @@ class Package extends \PEAR2\SimpleChannelFrontend\Package
         parent::__construct($options);
         $this->cache = new \PEAR2\Cache\Lite\Main();
         $this->cache->setLifeTime(15 * 60);
-        
+
         $this->shortName = str_replace('PEAR2_', '', $this->name);
     }
     
@@ -64,7 +64,20 @@ class Package extends \PEAR2\SimpleChannelFrontend\Package
 
         if ($json === false) {
             $uri  = self::GIT_HUB_API . $this->shortName . '/issues?state=' . $state;
-            $json = file_get_contents($uri);
+            $json = file_get_contents(
+                $uri, false,
+                stream_context_create(
+                    array(
+                        'http' => array(
+                            'ignore_errors' => true
+                        )
+                    )
+                )
+            );
+            if (false === strpos($http_response_header[0], ' 200 ')) {
+                $json = false;
+            }
+
             if ($json === false) {
                 $json = $this->cache->get($key, 'default', false);
             } else {
@@ -81,12 +94,25 @@ class Package extends \PEAR2\SimpleChannelFrontend\Package
     
     protected function getGithubInfo()
     {
-        $key  = $this->name . "-wiki";
+        $key  = $this->name . "-info";
         $json = $this->cache->get($key);
 
         if ($json === false) {
             $uri  = self::GIT_HUB_API . $this->shortName;
-            $json = is_file($uri) && file_get_contents($uri);
+            $json = file_get_contents(
+                $uri, false,
+                stream_context_create(
+                    array(
+                        'http' => array(
+                            'ignore_errors' => true
+                        )
+                    )
+                )
+            );
+            if (false === strpos($http_response_header[0], ' 200 ')) {
+                $json = false;
+            }
+
             if ($json === false) {
                 $json = $this->cache->get($key, 'default', false);
             } else {


### PR DESCRIPTION
First stop, I'm sorry for this whole sequence of unfortunate oversights. I'm probably being a burden or something.

Although #22 worked with 5.4.4 on my copy, it doesn't work on the site (as in, the links are never displayed for any package). The README says PHP 5.3.2+ is required. I tried the site on my copy with 5.3.2, and indeed it didn't worked. This fixes this... assuming the site uses 5.3.2.

I don't know what else could possibly go wrong, but I'm starting to think that, by Murphy's law, if there is such a thing, it will go wrong :-D .

**NOTE:** You may have to clear the Cache_Lite cache.
